### PR TITLE
Fix: TextInputPanel: Handle exception in Shell and GUI properly as in…

### DIFF
--- a/src/main/java/org/opennars/gui/input/TextInputPanel.java
+++ b/src/main/java/org/opennars/gui/input/TextInputPanel.java
@@ -46,6 +46,7 @@ import org.opennars.gui.FileTreeModel;
 
 import static org.opennars.gui.output.SwingLogPanel.setConsoleFont;
 import org.opennars.io.events.OutputHandler.OUT;
+import org.opennars.main.Parameters;
 
 
 public class TextInputPanel extends NPanel /*implements ActionListener*/ {
@@ -217,8 +218,7 @@ public class TextInputPanel extends NPanel /*implements ActionListener*/ {
 
             @Override
             public String run() {
-                evaluateSeq(input);
-                return "";
+                return evaluateSeq(input);
             }
 
             @Override
@@ -271,15 +271,21 @@ public class TextInputPanel extends NPanel /*implements ActionListener*/ {
             */
         }
         
-        public void evaluateSeq(String input) {
+        public String evaluateSeq(String input) {
             //TODO make sequential evaluation
-            nar.addInput(input);
+            try{
+                nar.addInput(input);
+            }
+            catch(Exception ex) {
+                if(Parameters.DEBUG) {
+                    throw new IllegalStateException("error parsing:" + input, ex);
+                }
+                return input;
+            }
             nar.cycles(1);
+            return "";
         }
-
-        
     }
-    
     private final Nar nar;
 
     /**


### PR DESCRIPTION
… v1.6.5, so that the system does not crash.